### PR TITLE
multi-faction date background color corrections

### DIFF
--- a/src/TimelineEntry.css
+++ b/src/TimelineEntry.css
@@ -27,7 +27,7 @@
     margin-inline: calc(var(--inlineP) * -1);
 
     text-align: center;
-    background-color: var(--accent-color);
+    background-color: var(--accent-color-1);
 
     color: white;
     font-size: 1.25rem;
@@ -43,7 +43,7 @@
     content: "";
     width: var(--inlineP);
     aspect-ratio: 1;
-    background: var(--accent-color);
+    background: var(--accent-color-1);
     background-image: linear-gradient(rgba(0, 0, 0, 0.2) 100%, transparent);
     position: absolute;
     top: 100%;
@@ -59,7 +59,7 @@
     width: 2rem;
     aspect-ratio: 1;
     background: var(--bgColor);
-    border: 0.3rem solid var(--accent-color);
+    border: 0.3rem solid var(--accent-color-1);
     border-radius: 50%;
     top: 50%;
 
@@ -214,13 +214,33 @@ li.timeline-entry .factions .voladores {
         left: calc(100% + var(--col-gap) + var(--line-w) / 2);
     }
 
-    .timeline ul li:nth-child(odd) .date {
-        background-image: linear-gradient(120deg, var(--accent-color) 88%, var(--bgColor) 88.5%, var(--bgColor) 89%, var(--accent-color) 89.5%, var(--accent-color) 90.5%, var(--bgColor) 91%, var(--bgColor) 91.5%, var(--accent-color) 92%, var(--bgColor) 92.75%);
+    .timeline ul li:nth-child(odd).factions-1 .date {
+        background-image: linear-gradient(120deg, var(--accent-color-1) 88%, var(--bgColor) 88.5%, var(--bgColor) 89%, var(--accent-color-1) 89.5%, var(--accent-color-1) 90.5%, var(--bgColor) 91%, var(--bgColor) 91.5%, var(--accent-color-1) 92%, var(--bgColor) 92.75%);
         background-size: 100%;
     }
 
-    .timeline ul li:nth-child(even) .date {
-        background-image: linear-gradient(240deg, var(--accent-color) 88%, var(--bgColor) 88.5%, var(--bgColor) 89%, var(--accent-color) 89.5%, var(--accent-color) 90.5%, var(--bgColor) 91%, var(--bgColor) 91.5%, var(--accent-color) 92%, var(--bgColor) 92.75%);
+    .timeline ul li:nth-child(even).factions-1 .date {
+        background-image: linear-gradient(240deg, var(--accent-color-1) 88%, var(--bgColor) 88.5%, var(--bgColor) 89%, var(--accent-color-1) 89.5%, var(--accent-color-1) 90.5%, var(--bgColor) 91%, var(--bgColor) 91.5%, var(--accent-color-1) 92%, var(--bgColor) 92.75%);
+        background-size: 100%;
+    }
+
+    .timeline ul li:nth-child(odd).factions-2 .date {
+        background-image: linear-gradient(120deg, var(--accent-color-1) 50%, var(--accent-color-2) 50.5%, var(--accent-color-2) 88%, var(--bgColor) 88.5%, var(--bgColor) 89%, var(--accent-color-2) 89.5%, var(--accent-color-2) 90.5%, var(--bgColor) 91%, var(--bgColor) 91.5%, var(--accent-color-2) 92%, var(--bgColor) 92.75%);
+        background-size: 100%;
+    }
+
+    .timeline ul li:nth-child(even).factions-2 .date {
+        background-image: linear-gradient(240deg, var(--accent-color-1) 50%, var(--accent-color-2) 50.5%, var(--accent-color-2) 88%, var(--bgColor) 88.5%, var(--bgColor) 89%, var(--accent-color-2) 89.5%, var(--accent-color-2) 90.5%, var(--bgColor) 91%, var(--bgColor) 91.5%, var(--accent-color-2) 92%, var(--bgColor) 92.75%);
+        background-size: 100%;
+    }
+
+    .timeline ul li:nth-child(odd).factions-3 .date {
+        background-image: linear-gradient(120deg, var(--accent-color-1) 33%, var(--accent-color-2) 33.5%, var(--accent-color-2) 66% , var(--accent-color-3) 66.5%, var(--accent-color-3) 88%, var(--bgColor) 88.5%, var(--bgColor) 89%, var(--accent-color-3) 89.5%, var(--accent-color-3) 90.5%, var(--bgColor) 91%, var(--bgColor) 91.5%, var(--accent-color-3) 92%, var(--bgColor) 92.75%);
+        background-size: 100%;
+    }
+
+    .timeline ul li:nth-child(even).factions-3 .date {
+        background-image: linear-gradient(240deg, var(--accent-color-1) 33%, var(--accent-color-2) 33.5%, var(--accent-color-2) 66% , var(--accent-color-3) 66.5%, var(--accent-color-3) 88%, var(--bgColor) 88.5%, var(--bgColor) 89%, var(--accent-color-3) 89.5%, var(--accent-color-3) 90.5%, var(--bgColor) 91%, var(--bgColor) 91.5%, var(--accent-color-3) 92%, var(--bgColor) 92.75%);
         background-size: 100%;
     }
 

--- a/src/TimelineEntry.js
+++ b/src/TimelineEntry.js
@@ -16,23 +16,20 @@ function TimelineEntry({ indexVal, entry, factions, sources }) {
   var sourceKeyText = sourceKeys.join(' ');
 
   const numFactions = entry.factions.length;
-  const lastFaction = entry.factions[numFactions - 1];
-  var accentColor = factions[lastFaction].color;
-  var backgroundStyle = { "--accent-color": accentColor };
-  if (numFactions > 1) {
-    var angle = indexVal % 2 == 0 ? 120 : 240;
-    backgroundStyle = {
-      "backgroundImage": `linear-gradient(${angle}deg, ${entry.factions.map((faction, i) => `${factions[faction].color} ${i * 88 / numFactions}%, ${factions[faction].color} ${(i + 1) * 88 / numFactions}% `).join(",")}, var(--accent-color) 88%, var(--bgColor) 88.5%, var(--bgColor) 89%, var(--accent-color) 89.5%, var(--accent-color) 90.5%, var(--bgColor) 91%, var(--bgColor) 91.5%, var(--accent-color) 92%, var(--bgColor) 92.75%)`,
-      "--accent-color": `${accentColor}`
-    };
-  }
+
+  var accentColors = {};
+  entry.factions.map((faction, i) => {
+    var accentKey = "--accent-color-"+(i+1);
+    accentColors[accentKey] = factions[faction].color;
+  });
+  console.log(accentColors);
 
   return (
-    <li className={`timeline-entry ${entry.faction} ${sourceKeyText}`} style={{ "--accent-color": accentColor }}>
+    <li className={`timeline-entry ${sourceKeyText} factions-${numFactions}`} style={accentColors}>
       <div className="factions">{entry.factions.map((faction, i) => {
         return <span key={faction} className={faction} style={{"--faction-color": factions[faction].color}} title={factions[faction].name}/>;
       })}</div>
-      <div className="date" style={backgroundStyle}>{entry.year}{entry.era}</div>
+      <div className="date" style={accentColors}>{entry.year}{entry.era}</div>
       <div className="title">{entry.title}</div>
       <div className="descr">{entry.descr}</div>
       <div className="source" style={{ "--num-sources": entry.sources.length }}>


### PR DESCRIPTION
Problem:
Realized that the backgrounds for dates would get janky when adjusting timeline entry visibility. This was due to the dynamically generated linear-gradients created for any entry that has more than one faction associated with it.

Solution:
- create styles for entries having 1-3 factions associated
- change all `--accent-color` css variables to `--accent-color-#` where number is incrementing and contains each faction's color
- dynamically select the appropriate style based on the number of factions associated with an entry