### PR TITLE
Feature/timeline marker enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,33 @@ Example entry:
 }
 ```
 
+#### Marker Entries
+
+Marker entries are used to index specific points of time that don't have an associated timeline event. For instance, in the data there are marker entries for every 1000 years. This way users can save links that will take them directly to a specific year, or be able to search for a specific 1000 year block. Also note how `intraYearIndex` is added to make sure the record appears first.
+
+Example marker entry:
+
+```json
+{
+    "year": 5000,
+    "intraYearIndex": 1,
+    "marker": true,
+    "era": "U",
+    "factions": [
+        "no-faction"
+    ],
+    "title": "5000U Marker",
+    "descr": "",
+    "sources": [
+        {
+            "sourceKey": "no-source",
+            "sourceLocation": ""
+        }
+    ],
+    "uuid": "91e4e8c0-50a1-401d-bfa8-2bee7cbed0b9"
+}
+```
+
 It should be noted that timeline entries are automatically sorted by the React app. The sort order is descending `year` for entries in the `BU` era, and ascending `year` for entries in the `U` era.
 
 ## On Contributing

--- a/src/TimelineEntry.css
+++ b/src/TimelineEntry.css
@@ -20,6 +20,19 @@
     text-decoration: none;
 }
 
+/* timeline marker entry styles */
+.timeline ul li.marker .descr,
+.timeline ul li.marker .source,
+.timeline ul li.marker .factions {
+    display: none;
+    height: 0rem;
+    width: 0rem;
+    padding: 0rem;
+    margin: 0rem;
+}
+
+
+/* shareable link styles */
 .timeline ul li div.shareable-link {
     content: "";
     display: block;

--- a/src/TimelineEntry.js
+++ b/src/TimelineEntry.js
@@ -33,9 +33,12 @@ function TimelineEntry({ indexVal, entry, factions, sources, anchorId }) {
     }
   }, []);
 
+  /* add marker class for those timeline entries with {"marker": true} set */
+  var markerClass = entry.marker ? "marker" : "";
+
   return (
-    <li className={`timeline-entry ${sourceKeyText} factions-${numFactions}`} style={accentColors} ref={timelineEntryRef}>
-      <div id={entry.uuid} className="factions">{entry.factions.map((faction, i) => {
+    <li id={entry.uuid} className={`timeline-entry ${sourceKeyText} ${markerClass} factions-${numFactions}`} style={accentColors} ref={timelineEntryRef}>
+      <div className="factions">{entry.factions.map((faction, i) => {
         return <span key={faction} className={faction} style={{"--faction-color": factions[faction].color}} title={factions[faction].name}/>;
       })}</div>
       <div className="date" style={accentColors}>{entry.year}{entry.era}</div>

--- a/src/lancer-timeline-data.json
+++ b/src/lancer-timeline-data.json
@@ -111,6 +111,7 @@
             "year": 6000,
             "intraYearIndex": 1,
             "era": "BU",
+            "marker": true,
             "factions": [
                 "no-faction"
             ],
@@ -122,7 +123,7 @@
                     "sourceLocation": ""
                 }
             ],
-            "uuid": "04e4e8c0-50a1-401d-bfa8-2bee7cbed0b9"
+            "uuid": "04e4e8c1-50a1-401d-bfa8-2bee7cbed0b9"
         },
         {
             "year": 6000,
@@ -179,6 +180,7 @@
         {
             "year": 5000,
             "intraYearIndex": 1,
+            "marker": true,
             "era": "BU",
             "factions": [
                 "no-faction"
@@ -277,6 +279,7 @@
         {
             "year": 4000,
             "intraYearIndex": 1,
+            "marker": true,
             "era": "BU",
             "factions": [
                 "no-faction"
@@ -294,6 +297,7 @@
         {
             "year": 3000,
             "intraYearIndex": 1,
+            "marker": true,
             "era": "BU",
             "factions": [
                 "no-faction"
@@ -327,6 +331,7 @@
         {
             "year": 2000,
             "intraYearIndex": 1,
+            "marker": true,
             "era": "BU",
             "factions": [
                 "no-faction"
@@ -344,6 +349,7 @@
         {
             "year": 1000,
             "intraYearIndex": 1,
+            "marker": true,
             "era": "BU",
             "factions": [
                 "no-faction"
@@ -393,6 +399,7 @@
         {
             "year": 0,
             "intraYearIndex": 1,
+            "marker": true,
             "era": "U",
             "factions": [
                 "no-faction"
@@ -442,6 +449,7 @@
         {
             "year": 1000,
             "intraYearIndex": 1,
+            "marker": true,
             "era": "U",
             "factions": [
                 "no-faction"
@@ -577,7 +585,7 @@
             ],
             "title": "Aunic Planetary Control and First Enumenical Mandate",
             "descr": "1998-2100u. Integration of early Union colony, Anthem, under the Aun. The Aunic peoples establish control over Aun’Ist. The Ecumenical Mandate formally established.",
-            "uuid": "3d324401-d06c-4c09-94c6-0b6417574821",
+            "uuid": "3d324401-d06c-4c09-94c6-0b6417574822",
             "sources": [
                 {
                     "sourceKey": "fgaun",
@@ -588,6 +596,7 @@
         {
             "year": 2000,
             "intraYearIndex": 1,
+            "marker": true,
             "era": "U",
             "factions": [
                 "no-faction"
@@ -778,7 +787,7 @@
                     "sourceLocation": "pg. 338"
                 }
             ],
-            "uuid": "7aa855eb-5dda-4d32-8c8b-6aae3bda5f4b"
+            "uuid": "7aa855eb-5dda-4d32-8c8b-6aae3bda5f4c"
         },
         {
             "year": 2880,
@@ -886,6 +895,7 @@
         {
             "year": 3000,
             "intraYearIndex": 1,
+            "marker": true,
             "era": "U",
             "factions": [
                 "no-faction"
@@ -1149,6 +1159,7 @@
         {
             "year": 4000,
             "intraYearIndex": 1,
+            "marker": true,
             "era": "U",
             "factions": [
                 "no-faction"
@@ -1459,6 +1470,7 @@
         {
             "year": 5000,
             "intraYearIndex": 1,
+            "marker": true,
             "era": "U",
             "factions": [
                 "no-faction"
@@ -1481,7 +1493,7 @@
             ],
             "title": "Third Dawn Period",
             "descr": "Estimated beginning of Third Dawn Period. First contact of Crusade forces reported at Borea, Dodona, and Calvary -- all minor colony worlds in the Boundary Garden sector of Union space.",
-            "uuid": "2bbddca2-8717-4fbb-8dcc-4ac366e826e7",
+            "uuid": "2bb3dca2-8717-4fbb-8dcc-4ac366e826e7",
             "sources": [
                 {
                     "sourceKey": "fgaun",


### PR DESCRIPTION
Adds minor feature for timeline entries called markers. A marker is a slimmed down timeline entry used to denote a specific point in time that isn't related to an event. Currently, this is only being used to have entries for every 1000 years.

- adds a new field to timeline entries `marker: boolean`
- adds new styles for marker entries
