### PR TITLE
removes filter icons from entries with no-faction

### DIFF
--- a/src/TimelineEntry.js
+++ b/src/TimelineEntry.js
@@ -40,7 +40,7 @@ function TimelineEntry({ indexVal, entry, factions, sources, anchorId }) {
   return (
     <li id={entry.uuid} className={`timeline-entry ${sourceKeyText} ${markerClass} factions-${numFactions}`} style={accentColors} ref={timelineEntryRef}>
       <div className="factions">{entry.factions.map((faction, i) => {
-        return <span key={faction} className={faction} style={{ "--faction-color": factions[faction].color }} title={factions[faction].name} />;
+        return faction != 'no-faction' && <span key={faction} className={faction} style={{ "--faction-color": factions[faction].color }} title={factions[faction].name} />;
       })}</div>
       <div className="date" style={accentColors}>{entry.year}{entry.era}</div>
       <div className="title"><CopyLink elementId={entry.uuid} name={entry.title} />{entry.title}</div>

--- a/src/TimelineEntrySource.js
+++ b/src/TimelineEntrySource.js
@@ -5,7 +5,7 @@ function TimelineEntrySource({ sourceEntry, source }) {
 
   return (
     <div className={`timeline-entry-source ${sourceEntry.sourceKey}`}>
-      <a href={source.url}>{source.name}</a>{sourceLocation}
+      <a href={source.url} target="_blank">{source.name}</a>{sourceLocation}
     </div>
   );
 }


### PR DESCRIPTION
# Description

- adds a check to the faction icon code of timeline entries to not add a circle if the faction is `no-faction`
- being horrible and sneaking in timeline entry source link change to open in a new tab

## Issue Number
#30 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

